### PR TITLE
Fix TfSanitize forgotten @ symbol

### DIFF
--- a/terraform_utils/hcl.go
+++ b/terraform_utils/hcl.go
@@ -193,6 +193,7 @@ func TfSanitize(name string) string {
 	name = strings.Replace(name, ".", "--", -1)
 	name = strings.Replace(name, ":", "--", -1)
 	name = strings.Replace(name, "/", "--", -1)
+	name = strings.Replace(name, "@", "--", -1)
 	return name
 }
 


### PR DESCRIPTION
When importing users, we are setting the resource name to the user's email, which contains an `@` symbol. Within the previous version of TfSanitize, it did not check for the `@` symbol so it was not a valid resource name. This adds the check of the `@` symbol and replaces it with `--`