### PR TITLE
Change query for listing role grants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-plugin v1.0.1
 	github.com/hashicorp/hcl v1.0.1-0.20190611123218-cf7d376da96d
 	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6
-	github.com/hashicorp/terraform v0.12.9
+	github.com/hashicorp/terraform v0.12.10
 	github.com/heroku/heroku-go/v5 v5.1.0
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-tfe v0.3.8/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFMH0=
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
+github.com/hashicorp/go-tfe v0.3.23 h1:kd9hlFQvGubNF/CpF7T5AP/xU8uLUq8ANbI5xRDVSms=
+github.com/hashicorp/go-tfe v0.3.23/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -307,6 +309,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.1-0.20190611123218-cf7d376da96d h1:r4iSf+UX1tNxFJZ64FsUoOfysT7TePSbRNz4/mYGUIE=
 github.com/hashicorp/hcl v1.0.1-0.20190611123218-cf7d376da96d/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/hcl/v2 v2.0.0 h1:efQznTz+ydmQXq3BOnRa3AXzvCeTq1P4dKj/z5GLlY8=
+github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl2 v0.0.0-20180308163058-5f8ed954abd8/go.mod h1:xp1eMAxqhQKBxz+yQUTsig9bBMRRWRWw+rK3FJmHf/A=
 github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6 h1:JImQpEeUQ+0DPFMaWzLA0GdUNPaUlCXLpfiqkSZBUfc=
 github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
@@ -325,6 +329,8 @@ github.com/hashicorp/terraform v0.11.12-beta1.0.20190212191339-ee1f8f9362f3/go.m
 github.com/hashicorp/terraform v0.12.7/go.mod h1:dpIRVHTSvPpGZPDKBLEw3U7nNQaJCybZoZkeJSYxg/w=
 github.com/hashicorp/terraform v0.12.9 h1:ClfUndj2L94SWUiBRNikWBHu5+U/KmvaUKbLTbuo5mM=
 github.com/hashicorp/terraform v0.12.9/go.mod h1:qqvw7OZzW6mePSM0k2+rOzOD4U8YgHJF6T1qUCR7aAU=
+github.com/hashicorp/terraform v0.12.10 h1:+wKsR1FRWrHcbIdbzD9v99YDR+PwTOlzgW+NigGWeLA=
+github.com/hashicorp/terraform v0.12.10/go.mod h1:IwGTrz19rMZSVaU7ox2Wbmd4JrJEe5z6Q8EO98r7b6E=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4 h1:fTkL0YwjohGyN7AqsDhz6bwcGBpT+xBqi3Qhpw58Juw=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4/go.mod h1:JDmizlhaP5P0rYTTZB0reDMefAiJyfWPEtugV4in1oI=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=

--- a/providers/snowflake/snowflake_client.go
+++ b/providers/snowflake/snowflake_client.go
@@ -32,6 +32,7 @@ type client struct {
 type TfGrant struct {
 	Name      string
 	Privilege string
+	Users     []string
 	Roles     []string
 	Shares    []string
 }
@@ -157,12 +158,9 @@ type schemaGrant struct {
 
 type roleGrant struct {
 	CreatedOn   sql.NullString `db:"created_on"`
-	Privilege   sql.NullString `db:"privilege"`
-	GrantedOn   sql.NullString `db:"granted_on"`
-	Name        sql.NullString `db:"name"`
+	Role        sql.NullString `db:"role"`
 	GrantedTo   sql.NullString `db:"granted_to"`
 	GranteeName sql.NullString `db:"grantee_name"`
-	GrantOption sql.NullString `db:"grant_option"`
 	GrantedBy   sql.NullString `db:"granted_by"`
 }
 
@@ -319,7 +317,7 @@ func (sc *client) ListSchemaGrants(database database, schema schema) ([]schemaGr
 
 func (sc *client) ListRoleGrants(role role) ([]roleGrant, error) {
 	sdb := sqlx.NewDb(sc.db, "snowflake")
-	stmt := fmt.Sprintf(`SHOW GRANTS ON ROLE "%s"`, role.Name.String)
+	stmt := fmt.Sprintf(`SHOW GRANTS OF ROLE "%s"`, role.Name.String)
 	rows, err := sdb.Queryx(stmt)
 	if err != nil {
 		return nil, err
@@ -331,7 +329,7 @@ func (sc *client) ListRoleGrants(role role) ([]roleGrant, error) {
 		log.Printf("[DEBUG] no role grants found")
 		return nil, nil
 	}
-	return roleGrants, errors.Wrap(err, "unable to scan row for SHOW GRANTS ON ROLE")
+	return roleGrants, errors.Wrap(err, "unable to scan row for SHOW GRANTS OF ROLE")
 }
 
 func (sc *client) ListWarehouseGrants(warehouse warehouse) ([]warehouseGrant, error) {


### PR DESCRIPTION
`SHOW GRANTS OF ROLE` and `SHOW GRANTS ON ROLE` produce difference results. The difference is that when we use `OF`, we get different kinds of `granted_to` values like `USERS` and `ROLES` whereas using `ON`, we only get `ROLES` in the `granted_to` column. 

Using `OF` also has different column names than `ON`. This only needs to change for `role_grants`. The other types of grants remain the same.

Reference: https://docs.snowflake.net/manuals/sql-reference/sql/show-grants.html#variants